### PR TITLE
Fixed deprecated notice to implement unserializeData() and  serializeData()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-
+  - "5.3"
+  - "5.4"
+  - "5.5"
+  - "5.6"
+  - "7.0"
 env:
   - CONTAO_VERSION=~3.2.0
   - CONTAO_VERSION=~3.3.0

--- a/src/MetaModels/Attribute/Url/AttributeTypeFactory.php
+++ b/src/MetaModels/Attribute/Url/AttributeTypeFactory.php
@@ -10,8 +10,8 @@
  * @package    MetaModels
  * @subpackage AttributeUrl
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  The MetaModels team.
- * @license    LGPL-3+.
+ * @copyright  2012-2016 The MetaModels team.
+ * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/src/MetaModels/Attribute/Url/AttributeTypeFactory.php
+++ b/src/MetaModels/Attribute/Url/AttributeTypeFactory.php
@@ -10,6 +10,7 @@
  * @package    MetaModels
  * @subpackage AttributeUrl
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Christopher Boelter <christopher@boelter.eu>
  * @copyright  2012-2016 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource

--- a/src/MetaModels/Attribute/Url/Url.php
+++ b/src/MetaModels/Attribute/Url/Url.php
@@ -15,7 +15,7 @@
  * @author     Christopher Boelter <christopher@boelter.eu>
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Oliver Hoff <oliver@hofff.com>
- * @copyright  2012-2015 The MetaModels team.
+ * @copyright  2012-2016 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */

--- a/src/MetaModels/Attribute/Url/Url.php
+++ b/src/MetaModels/Attribute/Url/Url.php
@@ -15,8 +15,8 @@
  * @author     Christopher Boelter <christopher@boelter.eu>
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Oliver Hoff <oliver@hofff.com>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @copyright  2012-2015 The MetaModels team.
+ * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 
@@ -28,11 +28,6 @@ use MetaModels\DcGeneral\Events\UrlWizardHandler;
 
 /**
  * This is the MetaModelAttribute class for handling urls.
- *
- * @package    MetaModels
- * @subpackage AttributeUrl
- * @author     Stefan Heimes <stefan_heimes@hotmail.com>
- * @author     Andreas Isaak <info@andreas-isaak.de>
  */
 class Url extends BaseSimple
 {
@@ -107,5 +102,29 @@ class Url extends BaseSimple
         );
 
         return $arrFieldDef;
+    }
+
+    /**
+     * Take the raw data from the DB column and unserialize it.
+     *
+     * @param string $value The input value.
+     *
+     * @return mixed
+     */
+    public function unserializeData($value)
+    {
+        return deserialize($value);
+    }
+
+    /**
+     * Take the unserialized data and serialize it for the native DB column.
+     *
+     * @param mixed $value The input value.
+     *
+     * @return string
+     */
+    public function serializeData($value)
+    {
+        return serialize($value);
     }
 }

--- a/src/MetaModels/DcGeneral/Events/UrlWizardHandler.php
+++ b/src/MetaModels/DcGeneral/Events/UrlWizardHandler.php
@@ -11,8 +11,8 @@
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Christopher Boelter <christopher@boelter.eu>
- * @copyright  The MetaModels team.
- * @license    LGPL-3+.
+ * @copyright  2012-2016 The MetaModels team.
+ * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 


### PR DESCRIPTION
With this PR I fixed the deprecated message ...

`<br><strong>Deprecated notice</strong>: Attribute type url should implement method unserializeData() and  serializeData(). in <strong>composer/vendor/metamodels/core/src/MetaModels/MetaModel.php</strong> on line <strong>462</strong>`

I also fixed a few build tool errors, to get this working again. Please check the PR and send me some feedback if there are an changes needed :)