### PR TITLE
Removed version_compare for >= 3.1

### DIFF
--- a/src/MetaModels/DcGeneral/Events/UrlWizardHandler.php
+++ b/src/MetaModels/DcGeneral/Events/UrlWizardHandler.php
@@ -79,30 +79,7 @@ class UrlWizardHandler
 
         $this->addStylesheet('metamodelsattribute_url', 'system/modules/metamodelsattribute_url/html/style.css');
 
-        if (version_compare(VERSION, '3.1', '>=')) {
-            $currentField = deserialize($model->getProperty($propName), true);
-
-            /** @var GenerateHtmlEvent $imageEvent */
-            $imageEvent = $event->getEnvironment()->getEventDispatcher()->dispatch(
-                ContaoEvents::IMAGE_GET_HTML,
-                new GenerateHtmlEvent(
-                    'pickpage.gif',
-                    $translator->translate('pagepicker', 'MSC'),
-                    'style="vertical-align:top;cursor:pointer"'
-                )
-            );
-
-            $event->getWidget()->wizard = ' <a href="contao/page.php?do=' . \Input::get('do') .
-                '&amp;table=' . $this->metaModel->getTableName() . '&amp;field=' . $inputId .
-                '&amp;value=' . str_replace(array('{{link_url::', '}}'), '', $currentField[1]) . '" title="' .
-                specialchars($translator->translate('pagepicker', 'MSC')) .
-                '" onclick="Backend.getScrollOffset();Backend.openModalSelector({\'width\':765,\'title\':\'' .
-                specialchars(str_replace("'", "\\'", $translator->translate('page.0', 'MOD'))) .
-                '\',\'url\':this.href,\'id\':\'' . $inputId . '\',\'tag\':\'ctrl_' . $inputId . '\',\'self\':this});' .
-                'return false">' . $imageEvent->getHtml() . '</a>';
-
-            return;
-        }
+        $currentField = deserialize($model->getProperty($propName), true);
 
         /** @var GenerateHtmlEvent $imageEvent */
         $imageEvent = $event->getEnvironment()->getEventDispatcher()->dispatch(
@@ -110,11 +87,21 @@ class UrlWizardHandler
             new GenerateHtmlEvent(
                 'pickpage.gif',
                 $translator->translate('pagepicker', 'MSC'),
-                'style="vertical-align:top;cursor:pointer" onclick="Backend.pickPage(\'ctrl_' . $inputId . '\')"'
+                'style="vertical-align:top;cursor:pointer"'
             )
         );
 
-        $event->getWidget()->wizard = ' ' . $imageEvent->getHtml();
+        $event->getWidget()->wizard = ' <a href="contao/page.php?do=' . \Input::get('do') .
+                                      '&amp;table=' . $this->metaModel->getTableName() . '&amp;field=' . $inputId .
+                                      '&amp;value=' . str_replace(array('{{link_url::', '}}'), '', $currentField[1])
+                                      . '" title="' .
+                                      specialchars($translator->translate('pagepicker', 'MSC')) .
+                                      '" onclick="Backend.getScrollOffset();Backend.openModalSelector({\'width\':765,\'title\':\''
+                                      .
+                                      specialchars(str_replace("'", "\\'", $translator->translate('page.0', 'MOD'))) .
+                                      '\',\'url\':this.href,\'id\':\'' . $inputId . '\',\'tag\':\'ctrl_' . $inputId
+                                      . '\',\'self\':this});' .
+                                      'return false">' . $imageEvent->getHtml() . '</a>';
     }
 
     /**


### PR DESCRIPTION
This PR removes a few lines of code that are not longer needed, because MetaModels support only Contao from version 3.2. So we don't need a compare for versions from 3.1, composer handles that for us.